### PR TITLE
change datatype for url column

### DIFF
--- a/plugins/RssFeedPlugin.php
+++ b/plugins/RssFeedPlugin.php
@@ -51,7 +51,7 @@ class RssFeedPlugin extends phplistPlugin
     public $DBstruct = array(
         'feed' => array(
             'id' => array('integer not null primary key auto_increment', 'ID'),
-            'url' => array('varchar(65535) not null', ''),
+            'url' => array('text not null', ''),
             'etag' => array('varchar(100) not null', ''),
             'lastmodified' => array('varchar(100) not null', ''),
         ),


### PR DESCRIPTION
On my system the "feed" table was not created. I traced it down to the following error in Mysql:
ERROR 1118 (42000): Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. You have to change some columns to TEXT or BLOBs

I think this change is safe, as there don't seem to be any indexes, so a varchar(65525) should be similar to a text field.
