### PR TITLE
implement sendMessageTabInsertBefore

### DIFF
--- a/plugins/RssFeedPlugin.php
+++ b/plugins/RssFeedPlugin.php
@@ -285,6 +285,12 @@ END;
         return 'RSS';
     }
 
+    public function sendMessageTabInsertBefore()
+    {
+        return 'Format';
+    }
+
+
     public function sendTestAllowed($messageData)
     {
 


### PR DESCRIPTION
A new method allows plugins to set the preference of where the tab needs to go. https://github.com/phpList/phplist3/commit/7ac9353708bc96ddd944bc529a8903b37133bae8

As the RSS data is "Content" a good place is before the Format tab
