### PR TITLE
handle Item->getTag being a string, instead of an array

### DIFF
--- a/plugins/RssFeedPlugin/Controller/Get.php
+++ b/plugins/RssFeedPlugin/Controller/Get.php
@@ -44,8 +44,10 @@ class RssFeedPlugin_Controller_Get
             } else {
                 $content = $values[0];
             }
-        } else {
+        } elseif (is_array($values)) {
             $content = $values[0];
+        } else {
+            $content = $values;
         }
 
         return $content;


### PR DESCRIPTION
I had a strange issue where the descriptions were only a single letter. I traced it down to this. The "Item" may return a string, not an array: https://github.com/bramley/phplist-plugin-common/blob/master/plugins/CommonPlugin/vendor/fguillot/picofeed/lib/PicoFeed/Parser/Item.php#L128
