### PR TITLE
Moved two menu items from "system" menu to "campaigns" menu

### DIFF
--- a/plugins/RssFeedPlugin.php
+++ b/plugins/RssFeedPlugin.php
@@ -38,9 +38,9 @@ class RssFeedPlugin extends phplistPlugin
     public $publicPages = array(self::TWITTER_PAGE);
 
     public $topMenuLinks = array(
-        'get' => array('category' => 'system'),
         'view' => array('category' => 'campaigns'),
-        'delete' => array('category' => 'system'),
+        'get' => array('category' => 'campaigns'),
+        'delete' => array('category' => 'campaigns'),
     );
 
     public $pageTitles = array(


### PR DESCRIPTION
Moves two rssfeed plugin menu items from the "system" menu to the "campaigns" menu: "Fetch RSS items" & "Delete outdated RSS items". Aside from improving the accessibility of these menu items by putting them in the more frequently accessed "Campaigns" menu, this change also makes the pages accessible on phpList Hosted, which does not make use of the "System" menu by default.
