### PR TITLE
Add ability to control the size of picofeeds max body size

### DIFF
--- a/plugins/RssFeedPlugin.php
+++ b/plugins/RssFeedPlugin.php
@@ -11,6 +11,8 @@
  * @license   http://www.gnu.org/licenses/gpl.html GNU General Public License, Version 3
  */
 
+use PicoFeed\Config\Config;
+
 /**
  * Registers plugin with phplist
  * Provides hooks into message processing.
@@ -73,7 +75,9 @@ class RssFeedPlugin extends phplistPlugin
 
     private function validateFeed($feedUrl)
     {
-        $reader = new PicoFeed\Reader\Reader();
+        $config = new Config();
+        $config->setMaxBodySize((int) getConfig('rss_max_body_size'));
+        $reader = new PicoFeed\Reader\Reader($config);
         $resource = $reader->download($feedUrl);
         $parser = $reader->getParser(
             $resource->getUrl(),
@@ -209,6 +213,15 @@ class RssFeedPlugin extends phplistPlugin
             'delete' => s('Delete outdated RSS items'),
         );
         $this->settings = array(
+            'rss_max_body_size' => array(
+                'description' => s('Maximum size of the HTTP body response allowed'),
+                'type' => 'integer',
+                'value' => 2097152, // 2MB
+                'allowempty' => 1,
+                'min' => 524288,
+                'max' => 16777216,
+                'category' => 'RSS',
+            ),
             'rss_minimum' => array(
                 'description' => s('Minimum number of items to send in an RSS email'),
                 'type' => 'integer',

--- a/plugins/RssFeedPlugin/Controller/Get.php
+++ b/plugins/RssFeedPlugin/Controller/Get.php
@@ -109,6 +109,7 @@ class Get extends Controller
     {
         $utcTimeZone = new DateTimeZone('UTC');
         $config = new Config();
+        $config->setMaxBodySize((int) getConfig('rss_max_body_size'));
         $config->setContentFiltering((bool) getConfig('rss_content_filtering'));
         $config->setContentGenerating((bool) getConfig('rss_content_generating'));
         $feeds = $dao->activeFeeds();


### PR DESCRIPTION
Per title, this allows users to adjust the picofeed max http body size. Atom feeds don't necessarily need to have a 2MB limit, so it'd be cool to set it larger. This allows a range of 512KB to 16MB which should be more than reasonable for RSS/Atom feeds.