### PR TITLE
Add the ability to use [RSS:N_ITEMS] in the subject of the email

### DIFF
--- a/plugins/RssFeedPlugin.php
+++ b/plugins/RssFeedPlugin.php
@@ -171,10 +171,19 @@ class RssFeedPlugin extends phplistPlugin
             }
         }
 
-        return $this->replaceProperties(
-            $subject,
-            array('RSSITEM:TITLE' => $titleReplace)
-        );
+        // add RSSITEM:TITLE
+        $subject = $this->replaceProperties(
+                    $subject,
+                    array('RSSITEM:TITLE' => $titleReplace)
+                );
+
+        // add RSS:N_ITEMS
+        $subject = $this->replaceProperties(
+                    $subject,
+                    array('RSS:N_ITEMS' => $size)
+                );
+
+        return $subject;
     }
 
     private function modifySubject(array $messageData, array $items)


### PR DESCRIPTION
This diff enable us to create a newsletter that says in the subject how many RSS items are in the email, using the new [RSS:N_ITEMS] placeholder.

E.g.:
`This e-mail has [RSS:N_ITEMS] new posts for you (e.g.: [RSSITEM:TITLE] )`