### PR TITLE
[DO NOT MERGE] From published to added

### DIFF
--- a/plugins/RssFeedPlugin/DAO.php
+++ b/plugins/RssFeedPlugin/DAO.php
@@ -147,7 +147,7 @@ class DAO extends CommonDAO
     public function messageFeedItems($mid, $limit, $useEmbargo = true)
     {
         $published = $useEmbargo
-            ? 'AND it.published >= m.embargo - INTERVAL m.repeatinterval MINUTE AND it.published < m.embargo'
+            ? 'AND it.added >= m.embargo - INTERVAL m.repeatinterval MINUTE AND it.added < m.embargo'
             : '';
         $subquery =
             "SELECT id


### PR DESCRIPTION
Making the plugin work with "added" dates instead of "published" dates. (i.e.: #31 )
This is an ugly hack, but in case someone wants to do it before it's implemented "properly", this seems to work.
(it wouldn't be ideal for when purging the RSS items though...)


This PR should be rejected. I'm only placing it here in case others want to use "added" time instead of "published" feed time, before the (wonderful :) ) plugin author gets to add it properly.